### PR TITLE
Activeadmin version should not be constrained

### DIFF
--- a/activeadmin_trumbowyg.gemspec
+++ b/activeadmin_trumbowyg.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0")
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activeadmin', '~> 1.0'
+  spec.add_runtime_dependency 'activeadmin'
 end


### PR DESCRIPTION
This constraint makes it impossible to use the gem with ActiveAdmin 2, while they work just fine together.
I think this should be left unconstrained since you don't really use much of ActiveAdmin functionality.