### PR TITLE
Remove active_admin version constraint

### DIFF
--- a/activeadmin_trumbowyg.gemspec
+++ b/activeadmin_trumbowyg.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0")
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activeadmin', '~> 1.0'
+  spec.add_runtime_dependency 'activeadmin', '>= 1.0'
 end


### PR DESCRIPTION
At the moment, this gem doesn't work on active admin 2.0. 

This is a lazy way of making it work with AA 2.0